### PR TITLE
Better title tags for pages

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,7 +2,14 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Felix Krause</title>
+
+  <title>
+    {% if page.title == "Home" %}
+      {{ site.title }}
+    {% else %}
+      {{ page.title }} &middot; {{ site.title }}
+    {% endif %}
+  </title>
   
   <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title | escape }}" href="{{ "/feed.xml" | relative_url }}">

--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+title: Home
 ---
 
 <div class="home">


### PR DESCRIPTION
Posts now have their title in the title tag, so it is not all "Felix Krause" any more.

Googlebot will like that, right now it is guessing and sometimes getting the wrong one: https://www.google.de/search?q=site%3Akrausefx.com